### PR TITLE
add flask response support

### DIFF
--- a/flask_openapi3/utils.py
+++ b/flask_openapi3/utils.py
@@ -332,6 +332,8 @@ def get_responses(
         if response is None:
             # If the response is None, it means HTTP status code "204" (No Content)
             _responses[key] = Response(description=HTTP_STATUS.get(key, ""))
+        elif inspect.isclass(response) and issubclass(response, FlaskResponse):
+                _responses[key] = Response(description=HTTP_STATUS.get(key, ""))
         elif isinstance(response, dict):
             response["description"] = response.get("description", HTTP_STATUS.get(key, ""))
             _responses[key] = Response(**response)

--- a/tests/test_sano.py
+++ b/tests/test_sano.py
@@ -1,0 +1,18 @@
+"""test additional functionality added to the sano fork of flask_openapi3"""
+from http import HTTPStatus
+from flask_openapi3 import OpenAPI
+from flask import Flask, Blueprint, Response
+
+def test_flask_responses():
+    sano_flask = Flask(__name__)
+    blueprint = Blueprint("test", __name__)
+
+    @blueprint.route("/hello")
+    def handler() -> Response:
+        return Response(status=HTTPStatus.OK)
+    
+    sano_flask.register_blueprint(blueprint)
+    api = OpenAPI(__name__)
+    api.collect_metadata(sano_flask)
+    api.generate_spec_json()
+    assert api.spec_json['paths']['/hello']['get']['responses'] == {'200': {'description': 'OK'}}


### PR DESCRIPTION
we dont currently support endpoints that return a `flask.Response` type (see example in test)